### PR TITLE
Corrected mistake ❌ in contribution card in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ Incase you have anything to be followed while executing the python script mentio
 
 
 ### Project Contributors
-<a href="https://github.com/vinayskywalker/Hactoberfest2022/graphs/contributors">
-<img src="https://contrib.rocks/image?repo=vinayskywalker/Hactoberfest2022" />
+<a href="https://github.com/DhanushNehru/Python-Scripts/graphs/contributors">
+<img src="https://contrib.rocks/image?repo=DhanushNehru/Python-Scripts" />
 </a>


### PR DESCRIPTION
Previously I added the contribution card of another repo accidentally. Changed it to the contributors card of this repo. Sorry!