### PR TITLE
image compressor added

### DIFF
--- a/ImageCompress/compressor.py
+++ b/ImageCompress/compressor.py
@@ -1,0 +1,6 @@
+from PIL import Image
+file_path = "path_of_image"
+img = Image.open(file_path)
+height, width = img.size
+compressed = img.resize((height, width), Image.ANTIALIAS)
+compressed.save("compressedImage.jpg", optimize=True, quality=9)


### PR DESCRIPTION
Added a script for Compressing images according to set parameters. I have tested it on `quality=9`

The image quality is on a scale from 1 (worst) to 95 (best). The default is 75. Values above 95 should be avoided; 100 disables portions of the JPEG compression algorithm, and results in large files with hardly any gain in image quality.