### PR TITLE
Added support to download audio output only

### DIFF
--- a/Youtube Downloader/youtubeDownloader.py
+++ b/Youtube Downloader/youtubeDownloader.py
@@ -5,10 +5,10 @@ def my_hook(d):
         print(f"Done downloading, now post-processing ... File saved as: {d['filename']}")
 
 ydl_opts = {
-    'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best',
     'ffmpeg_location': r'Youtube Downloader\bin',
     'progress_hooks': [my_hook],
     'outtmpl': '%(title)s.%(ext)s',
+    'restrictfilenames': 'True',
 }
 
 
@@ -25,9 +25,14 @@ def downloader():
     else:
         URLS.append(input('Enter Video URL: '))
 
+    question = input("Do you want audio output only (Y/n): ").lower()
+    if question == 'y':
+        ydl_opts['format'] = 'bestaudio[ext=m4a]/best,'
+    else:
+        ydl_opts['format'] = 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best,'
+
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         ydl.download(URLS)
-
-
+    
 if __name__ == "__main__":
     downloader()


### PR DESCRIPTION
# Added support to download audio output only

## Summary

First of all thanks for providing awesone python scripts.
Sometime we need to download youtube video as audio files only. I have added that support in youtubeDownloader.py. I also observed "UnicodeEncodeError" error for few videos. Added fix for that also.

## Description

Added option to download only audio output of youtube video

### The changes are as follows:
- Modified code to configure ydl_opts['format'] option to only audio or audio+video based on input provide
- Observed `"UnicodeEncodeError: 'charmap' codec can't encode character '\uff5c' in position 86: character maps to <undefined>"` error while downloading few of the videos. Added `'restrictfilenames': 'True',` option to fix this. Refer - https://github.com/yt-dlp/yt-dlp/issues/5819

## Checks

Validated downloads with multiple videos. 

### in the repository

- [x] Made no changes that degrades the functioning of the repository
- [x] Gave each commit a better title (unlike updated README.md)

### in the PR
- [x] Followed the format of the pull_request_template
- [x] Made the Pull Request in a small level (for the creator's wellfare)
- [x] Tested the changes you made 

<!-- Dont worry even if your PR doesn't satisfy every checks make sure it atleast does any two(including the first one) -->

Thank You,

Shailesh Vaidya