### PR TITLE
Added Image to URL using imgbb (with apikey)

### DIFF
--- a/Image to URL/uploadimage.py
+++ b/Image to URL/uploadimage.py
@@ -1,0 +1,57 @@
+import base64
+import requests
+import pyperclip as pc
+from PIL import ImageGrab, Image
+import os
+from dotenv import load_dotenv
+
+
+device = "mac"
+# set device to "windows" if you are on windows, "mac" if you are on macOS
+# On windows this uses the keyboard library ( which works only on windows )
+# On Mac there is an alternative library called pynput but that requires a lot of permissions
+# Which frankly even I am not comfortable since there is a better alternative on mac :
+# Open Automator > Create New Document > Choose a Type : Quick Action > Search for "Run Shell Script" > Drag it to the right side > Set Workflow receives input : none > Change shell to python3 > Paste this script in there ( after you have configured everything , like the api_key ... )
+# Save that Quick Action. Go to Keyboard Shortcuts > Services > General > Assign your preffered shortcut for the Quick Action you just made.
+
+
+load_dotenv()
+dotenv_path = os.path.join(os.path.dirname(__file__), '../.env')
+api_key_imgbb = os.environ.get("API_KEY_IMGBB")
+# api_key_imgbb = "put your imgbb key here ( if not using .env)"
+
+
+def upload_imgbb():
+    img = ImageGrab.grabclipboard()  # grab the current clipboard
+
+    # check if the item is a non image
+    if img is None:
+        print("Last object was not an image")
+        return
+    # save the image
+    img.save('random.png', 'PNG')
+
+    # open that image in a fileobject
+    with open("random.png", "rb") as file:
+        url = "https://api.imgbb.com/1/upload"
+        payload = {
+            "key": api_key_imgbb,
+            "image": base64.b64encode(file.read()),
+        }
+
+        # send a post request
+        res = requests.post(url, payload)  # get the response here
+        link = res.json()["data"]["url"]
+        print(link)
+        # copy the link into our clipboard
+        pc.copy(link)
+    os.remove("random.png")
+
+
+if device == "windows":
+    import keyboard
+    # edit the shortcut (for windows ) here ( check keyboard library documentation/examples )
+    keyboard.add_hotkey("ctrl+shift+z", upload_imgbb)
+    keyboard.wait('esc')  # pressing esc will exit the background python file
+elif device == "mac" or device == "linux":
+    upload_imgbb()


### PR DESCRIPTION
Image to URL using imgbb api

## Description

Had a bit of problem while handling the functionality in mac. 
On windows it was okay, but mac apparently has a lot of problems if you want to listen to keyboard inputs ( to trigger the shortcut) 
So the solution was to not listen for the trigger on mac, but instead use the automator.app and create a workflow using the python file. 

## How to use it  ? 


### Windows : 
Install all the required python libraries 
change `device` to "windows".
Get api key from imgbb, and put it in .env in the root of this repository.
Change shortcut to whatever you want, by default its set to Ctrl + Shift + Z 
Change your escape button ( to close the script using keyboard ) , default is "Esc"


For Mac users : 
Change the `device` to "mac" 
Get API key , put it in .env in the root of this repository. 

( Theoretically you should be able to do this but I was not able to for some reason ) 

1. Open Automator > Create a new Quick Action Workflow
2. Drag "Run Shell Script" to the right side  > Change Workflow Receives to "no input"
3. Keep the shell as it is, change the script to `python3 <full path to script>` ( use python or python3 , whichever you have ) 
4. Save it, Go to Keyboard Shortcuts > Services > General > Set the Keyboard shortcut for this saved workflow 

But since I had a problem with this , this is how I did it : 

1. Open Automator > create new Quick Action workflow 
2. Drag "Run Shell Script" to the right side > Change Workflow Receives to "no input"
3. Change the shell to "python3" ( for me , could be different for you) , and then paste the entire script into automator 
4. Keep in mind , in doing so the api key has to be in the code , and not in the .env file., also comment out all the dotenv stuff.


Thanks.
