### PR TITLE
Value error in ChessBoard.py

### DIFF
--- a/Chess Board/ChessBoard.py
+++ b/Chess Board/ChessBoard.py
@@ -3,17 +3,17 @@ import numpy as np
 from matplotlib.colors import LogNorm
 
 dx, dy = 0.015, 0.05
-#numpy.arange returns evenly spaced values within a given interval
-x = np.arange(-04.0, 4.0, dx)
-y = np.arange(-04.0, 4.0, dy)
-#returns coordinate matrices from coordinate vectors
+# numpy.arange returns evenly spaced values within a given interval
+x = np.arange(-4.0, 4.0, dx)  # Corrected -04.0 to -4.0
+y = np.arange(-4.0, 4.0, dy)  # Corrected -04.0 to -4.0
+# returns coordinate matrices from coordinate vectors
 X, Y = np.meshgrid(x, y)
 
 extent = np.min(x), np.max(x), np.min(y), np.max(y)
 
 Z1 = np.add.outer(range(8), range(8)) % 2
 
-plt.imshow(Z1, cmap="binary_r", interpolation="nearest", extent =  extent, alpha=1)
+plt.imshow(Z1, cmap="binary_r", interpolation="nearest", extent=extent, alpha=1)
 
 plt.title("Chess Board", fontweight="bold")
 


### PR DESCRIPTION
There is a small issue in this code related to the range values for x and y. The values -04.0 should be -4.0 to correctly define the range. In Python, -04.0 is not valid syntax for a float.