### PR TITLE
Add CLI web scraper for URL title and snippets (fixes #499)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,25 @@ More information on contributing and the general code of conduct for discussion 
 If you liked this repository, support it by starring ⭐
 
 Thank You for being here :)
+## CLI Web Scraper
+
+A simple command-line web scraper that fetches a webpage and displays:
+
+- Page title
+- Up to 5 text snippets from paragraph content
+
+### Requirements
+- Python 3.x
+- requests
+- beautifulsoup4
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+Usage
+python cli_web_scraper.py https://example.com
+Example Output
+Title: Example Domain
+Snippets:
+- This domain is for use in illustrative examples in documents.
+

--- a/cli_web_scraper.py
+++ b/cli_web_scraper.py
@@ -1,0 +1,51 @@
+import requests
+from bs4 import BeautifulSoup
+import sys
+
+def scrape_url(url: str) -> dict:
+    """
+    Scrape the given URL and return a dict with the title
+    and a list of the first few text snippets.
+    """
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        print(f"Error: {e}")
+        return {}
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # get title
+    title = soup.title.string if soup.title else "No title found"
+
+    # get first few text snippets
+    snippets = []
+    for p in soup.find_all("p"):
+        text = p.get_text().strip()
+        if text:
+            snippets.append(text)
+        if len(snippets) >= 5:
+            break
+
+    return {"title": title, "snippets": snippets}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python cli_web_scraper.py <URL>")
+        return
+
+    url = sys.argv[1]
+    result = scrape_url(url)
+
+    if result:
+        print(f"Title: {result['title']}")
+        print("Snippets:")
+        for snippet in result["snippets"]:
+            print(f"- {snippet}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+


### PR DESCRIPTION
This PR adds a simple CLI web scraper script that:

- Accepts a URL via command line
- Fetches the webpage
- Prints the page title
- Prints up to 5 text snippets from paragraph content

Fixes #499.
