### PR TITLE
Solved Issue #551 regarding input validation in Connect Four

### DIFF
--- a/Connect Four/connectfour.py
+++ b/Connect Four/connectfour.py
@@ -6,7 +6,17 @@ board = [["-"] * 6, ["-"] * 6, ["-"] * 6, ["-"] * 6, ["-"] * 6, ["-"] * 6, ["-"]
 def gamePlayTwoPlayers(p1, p2):
     win = ""
     while win == "":
-        column = int(input("{}'s turn. Enter which column you would like to drop your piece into: ".format(p1)))
+        while True:
+            try:
+                choice = int(input("{}'s turn. Enter column (1-7): ".format(p1)))
+                if 1 <= choice <= 7:
+                    column = choice - 1
+                    break
+                else:
+                    print("Invalid column! Please choose a number between 1 and 7.")
+            except ValueError:
+                print("That's not a number! Please enter a digit from 1 to 7.")
+        
         connectFourBoard(column, "X")
 
         if check_vertical_win(p1, p2, column):
@@ -27,6 +37,16 @@ def gamePlayTwoPlayers(p1, p2):
             break
 
         column = int(input("{}'s turn. Enter which column you would like to drop your piece into: ".format(p2)))
+        while True:
+            try:
+                choice = int(input("{}'s turn. Enter column (1-7): ".format(p2)))
+                if 1 <= choice <= 7:
+                    column = choice - 1
+                    break
+                else:
+                    print("Invalid column! Please choose a number between 1 and 7.")
+            except ValueError:
+                print("That's not a number! Please enter a digit from 1 to 7.")
         connectFourBoard(column, "O")
 
         if check_vertical_win(p1, p2, column):

--- a/Connect Four/connectfour.py
+++ b/Connect Four/connectfour.py
@@ -36,7 +36,6 @@ def gamePlayTwoPlayers(p1, p2):
             print(check_negative_diagonal_win(p1, p2))
             break
 
-        column = int(input("{}'s turn. Enter which column you would like to drop your piece into: ".format(p2)))
         while True:
             try:
                 choice = int(input("{}'s turn. Enter column (1-7): ".format(p2)))


### PR DESCRIPTION
This PR addresses Issue #551, where the game would crash if a player entered a column number outside the valid range (1–7) or a non-integer value.

The fix ensures the game remains stable by implementing an input validation loop that keeps the player prompted until a valid selection is made.

**Changes Made**
- Added Input Validation: Wrapped the column selection in a while loop to catch out-of-bounds integers.

- User-Friendly Indexing: Adjusted the input logic so users can type 1–7 (human-readable) while the code processes it as 0–6 (zero-indexed).

- Error Handling: Added a try-except block to handle ValueError in case a user inputs a string or symbol instead of a number.

**Testing Performed**
- Out-of-Bounds Test: Entered 8, 0, and -1. The program correctly displayed an error message and re-prompted the user.

- Type Safety Test: Entered "A" and "!" to ensure the ValueError was caught.

- Boundary Test: Entered 1 and 7 to ensure the pieces were placed in the correct first and last columns of the array.